### PR TITLE
Replace dlopen with libloading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push]
+jobs:
+  rustfmt:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - run: rustfmt src/lib.rs --edition 2018 --check
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - run: cargo build --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "breadglx"
 version = "0.0.1"
-authors = ["John 'not_a_seagull' Nunley <jtnunley01@gmail.com>"]
+authors = ["John 'notgull' Nunley <jtnunley01@gmail.com>"]
 edition = "2018"
 
 [dependencies]
@@ -12,10 +12,10 @@ blocking = { version = "1.0.2", optional = true }
 breadx = { path = "../breadx", features = ["glx"] }
 cfg-if = "1"
 dashmap = "4.0.1"
-dlopen = "0.1.8"
 event-listener = { version = "2.5.1", optional = true }
 futures-lite = { version = "1.11.2", optional = true }
 libc = "0.2.81"
+libloading = "0.7"
 log = "0.4"
 once_cell = { version = "1.5.2" }
 tinyvec = { version = "1.1.0", features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ ahash = "0.6.2"
 async-executor = { version = "1.4.0", optional = true }
 async-lock = { version = "2.3.0", optional = true }
 blocking = { version = "1.0.2", optional = true }
-breadx = { path = "../breadx", features = ["glx"] }
+breadx = { version = "0.2", features = ["glx"] }
 cfg-if = "1"
 dashmap = "4.0.1"
 event-listener = { version = "2.5.1", optional = true }

--- a/src/dll.rs
+++ b/src/dll.rs
@@ -45,7 +45,8 @@ impl Dll {
             Some(func) => Some(mem::transmute_copy::<_, T>(&*func)),
             None => {
                 // load symbol from library
-                let sym: NonNull<c_void> = unsafe { self.lib.get(name.to_bytes_with_nul()).ok()?.into_raw() };
+                let sym: NonNull<c_void> =
+                    unsafe { self.lib.get(name.to_bytes_with_nul()).ok()?.into_raw() };
                 self.funcs.insert(name.into(), sym.clone());
                 Some(mem::transmute_copy::<_, T>(&sym))
             }

--- a/src/dri/dri3/drawable.rs
+++ b/src/dri/dri3/drawable.rs
@@ -4305,7 +4305,9 @@ where
                 async {
                     for buffer in (mem::take(&mut state.buffers)).iter_mut() {
                         if let Some(buffer) = mem::take(buffer) {
-                            free_buffer_arc_async(buffer, conn.clone(), screen.clone()).await.ok();
+                            free_buffer_arc_async(buffer, conn.clone(), screen.clone())
+                                .await
+                                .ok();
                         }
                     }
                 },


### PR DESCRIPTION
This commit replaces our usage of the `dlopen` crate with the `libloading` crate, in order to ensure we don't pull in `syn` and `quote` as dependencies, since we don't use the features they provide anyways.